### PR TITLE
Provide every screen with its own ViewModelStore and Lifecycle

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.animation:animation:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.lifecycle:lifecycle-runtime:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.16.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.animation:animation:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.lifecycle:lifecycle-runtime:2.5.1"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.16.1'

--- a/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
+++ b/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
@@ -16,28 +16,31 @@
 package com.zhuinden.simplestackcomposeintegration.core
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.TweenSpec
-import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.util.fastMaxBy
@@ -47,7 +50,6 @@ import com.zhuinden.simplestack.StateChange
 import com.zhuinden.simplestack.StateChanger
 import com.zhuinden.simplestackcomposeintegration.core.ComposeStateChanger.AnimationConfiguration.ComposableAnimationSpec
 import com.zhuinden.simplestackcomposeintegration.core.ComposeStateChanger.AnimationConfiguration.ComposableTransition
-import kotlinx.coroutines.launch
 
 /**
  * Composition local to access the key within screens.
@@ -97,18 +99,13 @@ abstract class DefaultComposeKey {
 class ComposeStateChanger(
     private val animationConfiguration: AnimationConfiguration = AnimationConfiguration()
 ) : AsyncStateChanger.NavigationHandler {
-    private var backstackState by mutableStateOf(BackstackState(animationConfiguration = animationConfiguration))
+    private var currentStateChange by mutableStateOf<StateChangeData?>(null)
 
     override fun onNavigationEvent(
         stateChange: StateChange,
         completionCallback: StateChanger.Callback
     ) {
-        this.backstackState =
-            BackstackState(
-                animationConfiguration = animationConfiguration,
-                stateChange = stateChange,
-                callback = completionCallback,
-            )
+        currentStateChange = StateChangeData(stateChange, completionCallback)
     }
 
     /**
@@ -184,166 +181,158 @@ class ComposeStateChanger(
         }
     }
 
-    private data class BackstackState(
-        private val animationConfiguration: AnimationConfiguration,
-        private val stateChange: StateChange? = null,
-        private val callback: StateChanger.Callback? = null,
-    ) {
-        @Composable
-        fun RenderScreen(modifier: Modifier = Modifier) {
-            val stateChange = stateChange ?: return
-            val callback = callback ?: return
+    private class StateChangeData(
+        val stateChange: StateChange,
+        val completionCallback: StateChanger.Callback
+    )
 
-            val saveableStateHolder = rememberSaveableStateHolder()
-
-            var completionCallback by remember { mutableStateOf<StateChanger.Callback?>(null) }
-
-            val topNewKey by rememberUpdatedState(newValue = stateChange.topNewKey<DefaultComposeKey>())
-            val topPreviousKey by rememberUpdatedState(newValue = stateChange.topPreviousKey<DefaultComposeKey>())
-
-            var isAnimating by remember { mutableStateOf(false) }
-
-            val lerping = remember { Animatable(0.0f) }
-
-            var animationProgress by remember { mutableStateOf(0.0f) }
-
-            var initialization by remember { mutableStateOf(true) }
-
-            if (completionCallback !== callback) {
-                completionCallback = callback
-
-                if (topPreviousKey != null) {
-                    initialization = false
-
-                    animationProgress = 0.0f
-                    isAnimating = true
-                } else {
-                    initialization = true
-                }
-            }
-
-            var fullWidth by remember { mutableStateOf(0) }
-            var fullHeight by remember { mutableStateOf(0) }
-
-            val measurePolicy = MeasurePolicy { measurables, constraints ->
-                val placeables = measurables.fastMap { it.measure(constraints) }
-                val maxWidth = placeables.fastMaxBy { it.width }?.width ?: 0
-                val maxHeight = placeables.fastMaxBy { it.height }?.height ?: 0
-
-                if (fullWidth == 0 && maxWidth != 0) {
-                    fullWidth = maxWidth
-                }
-
-                if (fullHeight == 0 && maxHeight != 0) {
-                    fullHeight = maxHeight
-                }
-
-                layout(maxWidth, maxHeight) {
-                    placeables.fastForEach { placeable ->
-                        placeable.place(0, 0)
-                    }
-                }
-            }
-
-            val previousTransition = animationConfiguration.previousComposableTransition
-            val newTransition = animationConfiguration.newComposableTransition
-            
-            val contentWrapper = animationConfiguration.contentWrapper
-
-            var initialNewKey by remember { mutableStateOf(topNewKey) }
-
-            val newKeys by rememberUpdatedState(newValue = stateChange.getNewKeys<DefaultComposeKey>())
-            val previousKeys by rememberUpdatedState(newValue = stateChange.getPreviousKeys<DefaultComposeKey>())
-
-            val allKeys by rememberUpdatedState(newValue = mutableListOf<DefaultComposeKey>().apply {
-                addAll(newKeys)
-
-                previousKeys.fastForEach { previousKey ->
-                    if (!newKeys.contains(previousKey)) {
-                        add(0, previousKey)
-                    }
-                }
-            }.toList())
-
-            Layout(
-                content = {
-                    allKeys.fastForEach { key ->
-                        key(key) {
-                            contentWrapper.ContentWrapper(stateChange = stateChange) {
-                                if (key == topNewKey || (isAnimating && key == initialNewKey)) {
-                                    saveableStateHolder.SaveableStateProvider(key = key.saveableStateProviderKey) {
-                                        Box(
-                                            modifier = when {
-                                                !isAnimating || initialization -> modifier
-                                                else -> when {
-                                                    key == topNewKey -> newTransition.animateComposable(modifier, stateChange, fullWidth, fullHeight, animationProgress)
-                                                    else -> previousTransition.animateComposable(modifier, stateChange, fullWidth, fullHeight, animationProgress)
-                                                }
-                                            }
-                                        ) {
-                                            key.RenderComposable(modifier)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                measurePolicy = measurePolicy,
-            )
-
-            val coroutineScope = rememberCoroutineScope()
-
-            DisposableEffect(key1 = completionCallback, effect = {
-                @Suppress("NAME_SHADOWING")
-                val topNewKey = topNewKey // ensure this is kept while the animation is progressing, I guess?
-
-                @Suppress("NAME_SHADOWING")
-                val completionCallback = completionCallback  // ensure this is kept while the animation is progressing, I guess?
-
-                val job = coroutineScope.launch {
-                    if (isAnimating) {
-                        lerping.animateTo(1.0f, animationConfiguration.animationSpec.defineAnimationSpec(stateChange = stateChange)) {
-                            animationProgress = this.value
-                        }
-                        isAnimating = false
-                        lerping.snapTo(0f)
-                    }
-                    initialNewKey = topNewKey
-
-                    previousKeys.fastForEach { previousKey ->
-                        if (!newKeys.contains(previousKey)) {
-                            saveableStateHolder.removeState(previousKey.saveableStateProviderKey)
-                        }
-                    }
-
-                    try {
-                        completionCallback!!.stateChangeComplete()
-                    } catch(e: IllegalStateException) {
-                        Log.i("ComposeStateChanger", "Unexpected double call to completion callback", e)
-                    }
-                }
-
-                onDispose {
-                    try {
-                        if (!job.isCompleted) {
-                            job.cancel()
-                        }
-                    } catch (e: Throwable) {
-                        // I don't think this can happen, but even if it did, it wouldn't be useful here.
-                        // Having to cancel the job would only happen if the animation is in progress while the composable is removed.
-                    }
-                }
-            })
-        }
-    }
+    private data class DisplayedKey(
+        val key: DefaultComposeKey,
+        val transition: ComposableTransition?,
+        val animationProgress: State<Float>
+    )
 
     @Composable
     fun RenderScreen(modifier: Modifier = Modifier) {
         LocalBackstack.current // force `BackstackProvider` to be set
 
-        backstackState.RenderScreen(modifier)
+        val currentStateChange = currentStateChange ?: return
+
+        val displayedKeys = remember { mutableStateOf(emptyList<DisplayedKey>()) }
+
+        DetermineDisplayedScreens(currentStateChange, displayedKeys)
+
+        DisplayScreens(displayedKeys, modifier, currentStateChange)
     }
+
+    @Composable
+    private fun DisplayScreens(
+        displayedKeys: State<List<DisplayedKey>>,
+        modifier: Modifier,
+        currentStateChange: StateChangeData
+    ) {
+        val saveableStateHolder = rememberSaveableStateHolder()
+        CleanupStaleSavedStates(saveableStateHolder)
+
+        val measurePolicy = remember { SizeSavingMeasurePolicy() }
+        Layout({
+            for (displayedKey in displayedKeys.value) {
+                val animationModifier = displayedKey.transition?.animateComposable(
+                    modifier,
+                    currentStateChange.stateChange,
+                    measurePolicy.fullWidth,
+                    measurePolicy.fullHeight,
+                    displayedKey.animationProgress.value
+                ) ?: modifier
+
+                val key = displayedKey.key
+
+                key(key) {
+                    saveableStateHolder.SaveableStateProvider(key) {
+                        animationConfiguration.contentWrapper.ContentWrapper(
+                            currentStateChange.stateChange
+                        ) {
+                            key.RenderComposable(animationModifier)
+                        }
+                    }
+                }
+
+            }
+        }, Modifier, measurePolicy)
+    }
+
+    @Composable
+    private fun DetermineDisplayedScreens(
+        currentStateChange: StateChangeData,
+        displayedKeys: MutableState<List<DisplayedKey>>
+    ) {
+        LaunchedEffect(currentStateChange) {
+            val topNewKey = currentStateChange.stateChange.topNewKey<DefaultComposeKey>()
+            val topOldKey = currentStateChange.stateChange.topPreviousKey<DefaultComposeKey>()
+
+            if (topOldKey == null) {
+                // First state change, do not animate
+                displayedKeys.value = listOf(
+                    DisplayedKey(topNewKey, null, mutableStateOf(0f))
+                )
+                currentStateChange.completionCallback.stateChangeComplete()
+                return@LaunchedEffect
+            }
+
+
+            val animatable = Animatable(0f)
+            val animationProgress = mutableStateOf(0f)
+
+            displayedKeys.value = listOf(
+                DisplayedKey(
+                    topOldKey,
+                    animationConfiguration.previousComposableTransition,
+                    animationProgress
+                ),
+                DisplayedKey(
+                    topNewKey,
+                    animationConfiguration.newComposableTransition,
+                    animationProgress
+                )
+            )
+
+            val animationSpec = animationConfiguration.animationSpec.defineAnimationSpec(
+                currentStateChange.stateChange
+            )
+
+            animatable.animateTo(1f, animationSpec) {
+                animationProgress.value = value
+            }
+
+            displayedKeys.value = listOf(
+                DisplayedKey(topNewKey, null, mutableStateOf(0f))
+            )
+            currentStateChange.completionCallback.stateChangeComplete()
+        }
+    }
+
+    @Composable
+    private fun CleanupStaleSavedStates(saveableStateHolder: SaveableStateHolder) {
+        LaunchedEffect(currentStateChange) {
+            val stateChange = currentStateChange?.stateChange ?: return@LaunchedEffect
+            val previousKeys = stateChange.getPreviousKeys<Any>()
+            val newKeys = stateChange.getNewKeys<Any>()
+            previousKeys.fastForEach { previousKey ->
+                if (!newKeys.contains(previousKey)) {
+                    saveableStateHolder.removeState(previousKey)
+                }
+            }
+        }
+    }
+}
+
+private class SizeSavingMeasurePolicy : MeasurePolicy {
+    var fullWidth by mutableStateOf(0)
+    var fullHeight by mutableStateOf(0)
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeables = measurables.fastMap { it.measure(constraints) }
+        val maxWidth = placeables.fastMaxBy { it.width }?.width ?: 0
+        val maxHeight = placeables.fastMaxBy { it.height }?.height ?: 0
+
+        if (fullWidth == 0 && maxWidth != 0) {
+            fullWidth = maxWidth
+        }
+
+        if (fullHeight == 0 && maxHeight != 0) {
+            fullHeight = maxHeight
+        }
+
+        return layout(maxWidth, maxHeight) {
+            placeables.fastForEach { placeable ->
+                placeable.place(0, 0)
+            }
+        }
+    }
+
 }
 
 /**

--- a/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
+++ b/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
@@ -120,9 +120,17 @@ class ComposeStateChanger(
             ComposableTransition { modifier, stateChange, fullWidth, fullHeight, animationProgress ->
                 modifier.then(
                     when (stateChange.direction) {
-                        StateChange.FORWARD -> Modifier.graphicsLayer(translationX = 0 + (-1) * fullWidth * animationProgress)
-                        StateChange.BACKWARD -> Modifier.graphicsLayer(translationX = 0 + fullWidth * animationProgress)
-                        else /* REPLACE */ -> Modifier.graphicsLayer(alpha = (1 - animationProgress))
+                        StateChange.FORWARD -> Modifier.graphicsLayer {
+                            translationX = 0 + (-1) * fullWidth * animationProgress.value
+                        }
+
+                        StateChange.BACKWARD -> Modifier.graphicsLayer {
+                            translationX = 0 + fullWidth * animationProgress.value
+                        }
+
+                        else /* REPLACE */ -> Modifier.graphicsLayer {
+                            alpha = (1 - animationProgress.value)
+                        }
                     }
                 )
             },
@@ -134,9 +142,15 @@ class ComposeStateChanger(
             ComposableTransition { modifier, stateChange, fullWidth, fullHeight, animationProgress ->
                 modifier.then(
                     when (stateChange.direction) {
-                        StateChange.FORWARD -> Modifier.graphicsLayer(translationX = fullWidth + (-1) * fullWidth * animationProgress)
-                        StateChange.BACKWARD -> Modifier.graphicsLayer(translationX = -1 * fullWidth + fullWidth * animationProgress)
-                        else /* REPLACE */ -> Modifier.graphicsLayer(alpha = 0 + animationProgress)
+                        StateChange.FORWARD -> Modifier.graphicsLayer {
+                            translationX = fullWidth + (-1) * fullWidth * animationProgress.value
+                        }
+                        StateChange.BACKWARD -> Modifier.graphicsLayer {
+                            translationX = -1 * fullWidth + fullWidth * animationProgress.value
+                        }
+                        else /* REPLACE */ -> Modifier.graphicsLayer{
+                            alpha = 0 + animationProgress.value
+                        }
                     }
                 )
             },
@@ -150,7 +164,7 @@ class ComposeStateChanger(
         /**
          * An optional composable content wrapper.
          */
-        val contentWrapper: ComposableContentWrapper = object: ComposableContentWrapper {
+        val contentWrapper: ComposableContentWrapper = object : ComposableContentWrapper {
             @Composable
             override fun ContentWrapper(stateChange: StateChange, block: @Composable() () -> Unit) {
                 block()
@@ -162,7 +176,13 @@ class ComposeStateChanger(
          */
         fun interface ComposableTransition {
             @SuppressLint("ModifierFactoryExtensionFunction")
-            fun animateComposable(modifier: Modifier, stateChange: StateChange, fullWidth: Int, fullHeight: Int, animationProgress: Float): Modifier
+            fun animateComposable(
+                modifier: Modifier,
+                stateChange: StateChange,
+                fullWidth: Int,
+                fullHeight: Int,
+                animationProgress: State<Float>
+            ): Modifier
         }
 
         /**
@@ -222,7 +242,7 @@ class ComposeStateChanger(
                     currentStateChange.stateChange,
                     measurePolicy.fullWidth,
                     measurePolicy.fullHeight,
-                    displayedKey.animationProgress.value
+                    displayedKey.animationProgress
                 ) ?: modifier
 
                 val key = displayedKey.key

--- a/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/StoreHolderViewModel.kt
+++ b/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/StoreHolderViewModel.kt
@@ -1,0 +1,34 @@
+package com.zhuinden.simplestackcomposeintegration.core
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+
+internal class StoreHolderViewModel : ViewModel() {
+   private val viewModelStores = HashMap<Any, ViewModelStoreOwner>()
+
+   fun removeKey(key: Any) {
+      viewModelStores.remove(key)?.viewModelStore?.clear()
+   }
+
+   @Composable
+   fun WithLocalViewModelStore(key: Any, block: @Composable () -> Unit) {
+      val storeOwner = viewModelStores.getOrPut(key) {
+         val store = ViewModelStore()
+         ViewModelStoreOwner { store }
+      }
+
+      CompositionLocalProvider(LocalViewModelStoreOwner provides storeOwner) {
+         block()
+      }
+   }
+
+   override fun onCleared() {
+      for (store in viewModelStores.values) {
+         store.viewModelStore.clear()
+      }
+   }
+}


### PR DESCRIPTION
This PR depends on #17, so only last two commits are relevant. If #17 is rejected, I can also refactor this one to work with the old ComposeStateChanger.

PR provides every screen with their own:

* LifecycleOwner. Its lifecycle mimics parent activity's Lifecycle, except that it is destroyed whenever screen goes out of scope.
* ViewModelStore. It achieves that by creating its own ViewModel that holds references to the ViewModelStore of every screen in the backstack. Once screen leaves the backstack, its ViewModelStore is removed and all registered ViewModels are cleared.

This fixes #15.