### PR TITLE
animate outer Box, not screen's modifier

### DIFF
--- a/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
+++ b/core/src/main/java/com/zhuinden/simplestackcomposeintegration/core/ComposeIntegrationCore.kt
@@ -243,24 +243,23 @@ class ComposeStateChanger(
         val viewModelStores = viewModel<StoreHolderViewModel>()
         CleanupStaleSavedStates(saveableStateHolder, viewModelStores)
 
-        Box {
-            for (displayedKey in displayedKeys.value) {
+        for (displayedKey in displayedKeys.value) {
+            val key = displayedKey.key
+            key(key) {
                 val animationModifier = displayedKey.transition?.animateComposable(
                     modifier,
                     currentStateChange.stateChange,
                     displayedKey.animationProgress
                 ) ?: modifier
 
-                val key = displayedKey.key
-
-                key(key) {
+                Box(animationModifier) {
                     saveableStateHolder.SaveableStateProvider(key) {
                         viewModelStores.WithLocalViewModelStore(key) {
                             LocalDestroyedLifecycle {
                                 animationConfiguration.contentWrapper.ContentWrapper(
                                     currentStateChange.stateChange
                                 ) {
-                                    key.RenderComposable(animationModifier)
+                                    key.RenderComposable(Modifier)
                                 }
                             }
                         }


### PR DESCRIPTION
This fixes #19 

Animations were applied on the RenderComposable's modifier instead of on the Box that we control. Screens in dogs example ignore this modifier, which is why animations are not playing.