### PR TITLE
Force ComposeKey subclasses to implement hashCode

### DIFF
--- a/example-simple/src/main/java/com/zhuinden/simplestackcomposedogexample/ComposeKey.kt
+++ b/example-simple/src/main/java/com/zhuinden/simplestackcomposedogexample/ComposeKey.kt
@@ -12,4 +12,6 @@ abstract class ComposeKey: DefaultComposeKey(), Parcelable, DefaultServiceProvid
 
     override fun bindServices(serviceBinder: ServiceBinder) {
     }
+
+    abstract override fun hashCode(): Int
 }


### PR DESCRIPTION
This fixes #24 by adding hashCode as an abstract member of the ComposeKey, forcing the developer to implement it.

Good news here is that `data class` automatically implements this, so if developer already uses data classes, nothing changes. But if developer uses either regular class or object, it forces him/her to implement proper hash code.